### PR TITLE
fix: ignore group_id changes in entitlements

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -96,4 +96,8 @@ resource "databricks_entitlements" "this" {
   workspace_access           = true
 
   depends_on = [databricks_group_member.this]
+
+  lifecycle {
+    ignore_changes = [group_id]
+  }
 }


### PR DESCRIPTION
Triggers on change to dependent resource that won't affect groups 